### PR TITLE
test: fix flaky tests

### DIFF
--- a/tests/test_shtuff.py
+++ b/tests/test_shtuff.py
@@ -89,6 +89,7 @@ class TestShtuff(unittest.TestCase):
         os.system("shtuff into receiver exit")
         receiver.expect('exit')
         receiver.expect('exit')
+        receiver.wait()
 
         out = subprocess.run("shtuff into receiver ls", shell=True, capture_output=True, encoding='utf-8')
         self.assertEqual(out.returncode, 1)
@@ -114,6 +115,7 @@ class TestShtuff(unittest.TestCase):
         os.system("shtuff into cheezeburgerz exit")
         receiver.expect('exit')
         receiver.expect('exit')
+        receiver.wait()
 
         out = subprocess.run("shtuff has cheezeburgerz", shell=True, capture_output=True, encoding='utf-8')
         self.assertEqual(out.returncode, 1)


### PR DESCRIPTION
For some reason, these tests starting failing on Python 3.11, I'm not exactly sure why. These tests do seem to be making an incorrect assumption that just because the text "exit" has been printed to the screen that that means the process has actually exited. So, now we just wait for the process to actually exit, and things seem to behave reliably now.